### PR TITLE
исправлено определение пути для ос linux

### DIFF
--- a/src/app/core/services/main.service.ts
+++ b/src/app/core/services/main.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject} from 'rxjs';
 import * as fs from 'fs';
 import * as xml2js from 'xml2js';
+import * as path from 'path';
 
 @Injectable({
   providedIn: 'root'
@@ -50,7 +51,7 @@ export class MainService {
   }
 
   createFile(folderPath, fileName) {
-    const filePath = folderPath + '\\' + fileName;
+    const filePath = path.join(folderPath, fileName);
     return new Promise(function(resolve, reject) {
       fs.writeFile(filePath, '', (err) => {
         err ? reject(err) : resolve(filePath);

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, EventEmitter } from '@angular/core';
 import * as fs from 'fs';
 
 import { MainService } from '../core/services/main.service';
+import * as path from 'path';
 
 const electron = require('electron')
 
@@ -37,7 +38,7 @@ export class MainComponent implements OnInit {
       this.files = JSON.parse(files);
     }
     if (selectedFile) {
-      this.selectedFile = this.folderPath + '\\' + selectedFile;
+      this.selectedFile = path.join(this.folderPath, selectedFile);
       this.showReportComponent = true;
     }
   }
@@ -77,7 +78,7 @@ export class MainComponent implements OnInit {
   **/
   onSendFileName(selectedFile: string) {
     localStorage.setItem('selectedFile', selectedFile)
-    this.selectedFile = this.folderPath + '\\' + selectedFile;
+    this.selectedFile = path.join(this.folderPath, selectedFile);
     this.showReportComponent = true;
   }
 
@@ -91,7 +92,7 @@ export class MainComponent implements OnInit {
   onCloseModal(show: Boolean) {
     if (show === false) { this.showModalNewReport = false; }
     this.files = JSON.parse(localStorage.getItem('files'));
-    this.selectedFile = this.folderPath + '\\' + localStorage.getItem('selectedFile');
+    this.selectedFile = path.join(this.folderPath, localStorage.getItem('selectedFile'));
     this.selectedFileName = localStorage.getItem('selectedFile');
     this.showReportComponent = true;
   }

--- a/src/app/shared/components/new-report-modal/new-report-modal.component.ts
+++ b/src/app/shared/components/new-report-modal/new-report-modal.component.ts
@@ -9,6 +9,7 @@ import { TaskModel } from '../../../core/models/report.model';
 import { FileModel } from './file.model';
 import { getYearsList, getWeeksList } from './date-util';
 import { getFirstReport } from './report-adapter';
+import * as path from 'path';
 
 @Component({
   selector: 'app-new-report-modal',
@@ -68,7 +69,7 @@ export class NewReportModalComponent implements OnInit {
   isExistLastReport(isOverwrite) {
     const currentIndex = this.filesList.findIndex(element => element.fileName === this.fileName);
     const lastReportName = this.filesList[currentIndex - 1].fileName;
-    this.mainService.isExistReport(this.folderPath + '\\' + lastReportName).then(result => {
+    this.mainService.isExistReport(path.join(this.folderPath, lastReportName)).then(result => {
       this.getDataFromLastReport(lastReportName, isOverwrite);
     }, error => {
       const emptyReportModel = getFirstReport();
@@ -77,7 +78,7 @@ export class NewReportModalComponent implements OnInit {
   }
 
   getDataFromLastReport(lastReportName, isOverwrite) {
-    this.mainService.getFileContent(this.folderPath + '\\' + lastReportName).then(result => {
+    this.mainService.getFileContent(path.join(this.folderPath, lastReportName)).then(result => {
       const report = this.adapterService.getModel(result);
       report.common.map(project => {
         project.employee.map(empl =>  {
@@ -91,7 +92,7 @@ export class NewReportModalComponent implements OnInit {
 
   saveReport(report, isOverwrite) {
     const reportXml = this.parseToXmlService.parseToXml(report);
-    this.mainService.saveFile(this.folderPath + '\\' + this.fileName, reportXml).then(result => {
+    this.mainService.saveFile(path.join(this.folderPath, this.fileName), reportXml).then(result => {
       const files = JSON.parse(localStorage.getItem('files'));
       if (isOverwrite) { files.splice(files.indexOf(this.fileName), 1); }
       files.push(this.fileName);

--- a/src/app/shared/components/report/common-part/common-part.component.ts
+++ b/src/app/shared/components/report/common-part/common-part.component.ts
@@ -13,6 +13,7 @@ import { FormServiceService } from '../../../../core/services/form-service.servi
 import {ParseToXmlService} from '../../../../core/services/parse-to-xml.service';
 import {MainService} from '../../../../core/services/main.service';
 import {SpecialItemModel} from '../../../../core/models/specialItem.model';
+import * as path from 'path';
 
 @Component({
   selector: 'app-common-part',
@@ -99,7 +100,7 @@ export class CommonPartComponent implements OnInit, OnChanges {
       });
 
       const content = this.parseToXmlService.parseToXml(formValue);
-      this.mainService.saveFile(localStorage.getItem('folderPath') + '\\' + localStorage.getItem('selectedFile'), content);
+      this.mainService.saveFile(path.join(localStorage.getItem('folderPath'), localStorage.getItem('selectedFile')), content);
     });
   }
 

--- a/src/app/shared/components/report/special-part/special-part.component.ts
+++ b/src/app/shared/components/report/special-part/special-part.component.ts
@@ -7,6 +7,7 @@ import {TaskModel} from '../../../../core/models/report.model';
 import {SpecialItemModel, SpecialTaskModel} from '../../../../core/models/specialItem.model';
 import {ParseToXmlService} from '../../../../core/services/parse-to-xml.service';
 import {MainService} from '../../../../core/services/main.service';
+import * as path from 'path';
 
 @Component({
   selector: 'app-special-part',
@@ -37,7 +38,7 @@ export class SpecialPartComponent implements OnInit, OnChanges {
     this.form.valueChanges.pipe(debounceTime(500)).subscribe(values => {
       const formValue = this.formService.getForm().getRawValue();
       const content = this.parseToXmlService.parseToXml(formValue);
-      this.mainService.saveFile(localStorage.getItem('folderPath') + '\\' + localStorage.getItem('selectedFile'), content);
+      this.mainService.saveFile(path.join(localStorage.getItem('folderPath'), localStorage.getItem('selectedFile')), content);
     });
   }
 


### PR DESCRIPTION
Метод path.join() объединяет все данные сегменты пути вместе, используя для этого заданный платформенный разделитель, и приводит полученный путь к нормальному виду.